### PR TITLE
Change node-sass version from 5.0.0 to 4.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint": "^7.21.0",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^7.7.0",
-    "node-sass": "^5.0.0",
+    "node-sass": "^4.12.0",
     "prettier": "^2.2.1",
     "protobufjs": "^6.10.2",
     "sass-loader": "^10.1.1"


### PR DESCRIPTION
Because all other projects current using 4.12.0

https://github.com/tendermint/dex-demo/blob/d82e84755131901a4ffac6bb2abf4c3f434d1ea8/ui/package.json#L36

https://github.com/tendermint/vue/blob/240fe66591ae55e0ba5d5e6b849502972cfc01e3/packages/template/package.json#L51

https://github.com/tendermint/vue/blob/240fe66591ae55e0ba5d5e6b849502972cfc01e3/packages/vue/package.json#L51